### PR TITLE
Add schedule to renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "extends": [
     "config:base"
   ],
+  "timezone": "America/New_York",
+  "schedule": ["before 10pm"],
   "tekton": {
     "fileMatch": ["\\.yaml$", "\\.yml$"],
     "pinDigests": true


### PR DESCRIPTION
Without it, it looks like renovatebot may only run on updates to the repository.